### PR TITLE
Add 4 new camp files and update TODO with new leads and exclusions

### DIFF
--- a/CAMP-AlienInLine.md
+++ b/CAMP-AlienInLine.md
@@ -1,0 +1,27 @@
+# Alien In-Line — Inline Skate Camp
+
+## Inline Skate Camp *(Ages 6–8 | Mixed)*
+
+**For her:** Learn to rollerblade from scratch — no experience needed! Gear is provided so she just shows up ready to skate. Lots of skate time plus traditional camp games and activities in between.
+
+**For you:** Inline skating skills camp taught by certified instructors. All safety gear included (skates, helmet, wrist guards, elbow/knee pads). Multiple NW Calgary locations within easy reach. Full-day format. Good choice for the "one or two outdoor skills" camp goal.
+
+- **Indoor/Outdoor:** Outdoor (community association facilities)
+- **Hours:** Full day (exact start/end times — call to confirm)
+- **Price:** $425/week (one 4-day week Aug 4–7 is $360)
+- **Location:** Multiple NW Calgary locations (see dates below)
+- **Prerequisites:** None — no prior skating experience required
+- **More info / Book:** https://alieninline.com/summer-skate-camps/
+- **Phone:** 403-262-4404 | info@alieninline.com
+- **Spots:**
+
+| Dates | Location | Distance from West Hillhurst | Spots (Age 6–8) |
+|---|---|---|---|
+| July 6–10 | Triwood Arena, NW | ~10 min ✅ | Waitlist |
+| July 20–24 | Huntington Hills Community Assoc., NW | ~20 min ✅ | Available |
+| Aug 4–7 (4 days) | North Glenmore Park Community Assoc., SW | ~20 min | Waitlist |
+| Aug 10–14 | (SW Calgary location) | ~20 min | Available |
+| Aug 17–21 | Montgomery Community Association, NW | ~10 min ✅ | Waitlist |
+| Aug 24–28 | Edgemont Community Association, NW | ~25 min ✅ | Available |
+
+> ⚠️ **Note:** The camp name is "Alien **In-Line**" — this is **inline skating** (rollerblades), not quad roller skates. Technique transfers but it's not identical to rollerskating. Confirm hours (full day start/end) when booking.

--- a/CAMP-ChinookMusic.md
+++ b/CAMP-ChinookMusic.md
@@ -1,0 +1,23 @@
+# Chinook School of Music — Magic of Music Camp
+
+## Magic of Music *(Ages 5–6 | Mixed)*
+
+**For her:** A full week of singing, dancing, rhythm games, crafts, acting, and dress-up — right in her wheelhouse. No instruments to learn; it's all about exploring music through movement and imagination.
+
+**For you:** Full-day music/arts camp taught by music educators. NW Calgary location. Combines multiple interests (singing, dancing, crafts, drama dress-up) into one week. No prior experience needed.
+
+- **Indoor/Outdoor:** Indoor
+- **Hours:** 9:00am–4:00pm Mon–Fri
+- **Before/After Care:** 8:00–9:00am and 4:00–5:00pm ($45 each or $80 combined)
+- **Price:** $375/week (supplies included)
+- **Location:** 1101 48 Ave NW, Calgary — ~15 min from West Hillhurst ✅
+- **Prerequisites:** None
+- **More info / Book:** https://www.chinookschoolofmusic.com/summerdaycamps
+- **Phone:** 403-246-8446 | info@chinookschoolofmusic.com
+- **Spots:**
+
+| Dates | Spots |
+|---|---|
+| TBD — check website | — |
+
+> ⚠️ **Note:** The older-age camps (ages 7–10: Musical Theatre, Drum & Strum, etc.) run at the same price and hours — worth revisiting when she's a year older. Age requirement is strictly enforced (child must be 5–6 for this camp).

--- a/CAMP-HeritagePark.md
+++ b/CAMP-HeritagePark.md
@@ -1,0 +1,28 @@
+# Heritage Park — Prairie Explorers Day Camp
+
+## Prairie Explorers Day Camp *(Ages 6–9 | Mixed)*
+
+**For her:** Explore Heritage Park's historical village like an adventurer — try bannock-making, fur trading, Indigenous traditions, antique crafts, and more hands-on pioneer activities. Different from any other camp on the list.
+
+**For you:** Outdoor, skills-focused living-history camp — exactly the kind of "outdoor and educational" week the parents are looking for. Run by Heritage Park staff within the park grounds. Full day with optional pre/aftercare. GST-exempt price.
+
+- **Indoor/Outdoor:** Mostly outdoor (Heritage Park grounds)
+- **Hours:** 9:30am–4:00pm Mon–Fri
+- **Before/After Care:** Pre-care from 8:30am, aftercare to 5:00pm (cost not listed)
+- **Price:** $325/week (GST exempt); Annual members and Heritage Club VIPs get 15% off
+- **Location:** Heritage Park Historical Village, 1900 Heritage Dr SW — ~20–25 min from West Hillhurst
+- **Prerequisites:** None
+- **More info / Book:** https://heritagepark.ca/summer-camps/
+- **Spots:**
+
+| Dates | Spots |
+|---|---|
+| July 6–10 | — |
+| July 13–17 | — |
+| July 20–24 | — |
+| July 27–31 | — |
+| Aug 3–7 | — |
+| Aug 10–14 | — |
+| Aug 17–21 | — |
+
+> Note: Campers may attend any number of days per week — not required to attend all 5. Bookings through Showpass (Visa/Mastercard).

--- a/CAMP-RundleCollege.md
+++ b/CAMP-RundleCollege.md
@@ -1,0 +1,45 @@
+# Rundle College — Summer Camps
+
+Multiple themed camps for Grades 1–3 (ages ~6–8). Camps are run in AM + PM "combo" pairs — you pick an AM and a PM activity for the week. Both halves are included in the weekly price.
+
+## Creative Souls + [PM Camp] *(Grades 1–3 | Mixed)*
+
+**For her:** Hands-on creative crafts, visual art projects, and mixed-media exploration — outdoors-inspired art that lets her imagination run wild.
+
+**For you:** Art/crafts half of the day; pair with Theatre or another PM camp for a full themed day.
+
+---
+
+## Theatre Camp *(Grades 1–3 | Mixed)*
+
+**For her:** Drama games, storytelling, character play — building her own little performance with other kids. Right up her alley for a child who loves stories.
+
+**For you:** Skills-building through drama; builds confidence and creativity.
+
+---
+
+## LEGO® Camp *(Grades 1–3 | Mixed)*
+
+**For her:** Building and storytelling with LEGO — mid-tier interest satisfied!
+
+---
+
+**Shared Details (all Rundle camps):**
+
+- **Indoor/Outdoor:** Mixed (indoor facilities + outdoor space on campus)
+- **Hours:** 8:30am–3:30pm Mon–Fri (extended care 8:00–8:30am and 3:30–4:00pm at no charge)
+- **Price:** $340–$420/week (combo AM+PM)
+- **Location:** 7615 17 Avenue SW, Calgary — ~20–25 min from West Hillhurst
+- **Prerequisites:** None
+- **More info / Book:** https://rundle.ab.ca/summercamps/
+- **Phone / Email:** 403-282-8411 | summercamps@rundle.ab.ca
+- **Spots:**
+
+| Dates | Spots |
+|---|---|
+| June 29–July 3 (Week 1) | — |
+| July 6–10 (Week 2) | — |
+| July 13–17 (Week 3) | — |
+| July 20–24 (Week 4) | — |
+
+> ⚠️ **Note:** Registration opened January 27, 2026. Only 4 weeks offered (ends July 24). Check available combinations on website — specific AM/PM pairings may have limited spots. Also note SW Calgary location (~20–25 min drive).

--- a/TODO.md
+++ b/TODO.md
@@ -44,6 +44,40 @@
 - **Action:** Call 403-561-4488 or email info@barjo.ca — get 2026 per-week pricing and confirm bus return time (camp ends 3pm at ranch — need to know when bus returns to Calgary).
 - **Website:** https://www.barjo.ca
 
+### Free House Dance Plus ✅✅ Very Close (NW)
+- **What:** Dance studio offering full- and half-day summer camps. Styles include Jazz, Tap, Ballet, Modern, Lyrical, Hip Hop, Musical Theatre — excellent fit for a child who loves dancing and performing.
+- **Ages:** Division 1 (ages 3–8) — she qualifies
+- **Location:** 2020 12 Ave NW, Calgary — ~5 min from West Hillhurst ✅✅
+- **Note:** 2026 summer camp details not yet published online ("check back in the new year"). Half-day and full-day options reportedly offered.
+- **Action:** Call 403-282-0555 or email fhdp@telusplanet.net — ask: (1) Is there a full-day option in 2026? (2) What are the dates and pricing? (3) Do they have a camp for ages 6–7?
+- **Website:** https://freehousedance.com/kids-teens/summer-camps-programs-for-kids-and-teens/
+
+### Calgary Junior Roller Derby — Junior Program ✅ Very Close (NW)
+- **What:** Junior roller derby program (ages 6–17) based at West Hillhurst Community Association. Seasonal intakes (fall/winter), no confirmed summer camp found — but worth asking.
+- **Ages:** 6–17 ✅
+- **Location:** West Hillhurst Community Association, 1940 6 Ave NW — ~5 min ✅✅
+- **Note:** Regular season runs fall/winter. No 2026 summer camp found online yet. The parent noted this club is "nearby" — worth a direct inquiry.
+- **Action:** Email juniors@calgaryrollerderby.com or info@calgaryrollerderby.com — ask: (1) Is there a summer camp or summer skating program for 2026? (2) What ages / skill levels does the junior program accept?
+- **Website:** https://calgaryrollerderby.com/
+
+### Alien In-Line — Confirm Hours ✅ Close (NW)
+- **What:** Inline skate camp, full day, ages 6–8, NW Calgary locations. CAMP file written — daily start/end times not confirmed.
+- **Action:** Call 403-262-4404 or email info@alieninline.com — confirm exact daily hours (full day start/end times). CAMP-AlienInLine.md already created.
+- **Website:** https://alieninline.com/summer-skate-camps/
+
+### Chinook School of Music — Confirm 2026 Dates ✅ Close (NW)
+- **What:** "Magic of Music" for ages 5–6, full day 9am–4pm, NW Calgary location. CAMP file written — 2026 specific dates not found.
+- **Action:** Call 403-246-8446 or email info@chinookschoolofmusic.com — confirm 2026 camp dates and remaining availability. CAMP-ChinookMusic.md already created.
+- **Website:** https://www.chinookschoolofmusic.com/summerdaycamps
+
+### PULSE Studios — Dance Camp (Hip Hop) ✅ Close (NW)
+- **What:** Hip hop dance camp (breaking, popping, locking, house), ages 6–15, 9am–4pm. In Crescent Heights (~10 min). Styles are more street/hip hop than classical — could be a fun stretch for her.
+- **Ages:** 6–15 ✅
+- **Location:** 110 10 Ave NW (Crescent Heights) — ~10 min from West Hillhurst ✅
+- **Note:** Registration opened January 25, 2026. Price not listed online.
+- **Action:** Call 403-452-2846 or email info@pulsestudios.ca — ask: (1) What are the 2026 weekly dates? (2) What is the per-week price? (3) Before/after care options?
+- **Website:** https://pulsestudios.ca/kids-summer-dance-camps
+
 ---
 
 ## ⏰ Excluded (for reference)
@@ -53,16 +87,20 @@
 | Aliki's Art House | Likely half-day only — needs confirmation | No (in TODO above) |
 | Neon Milkshake | AM only — half-day excluded | No |
 | CYPT half-day | Half-day excluded | No (full-day in CAMP-CYPT.md) |
-| AUArts Kids Camps | Age 9–12 — too old for now (save for Grade 4) | No |
+| AUArts Kids Camps | Ages 9–12 confirmed — too old for now (save for Grade 4) | No |
 | WinSport Archery | Age 9–14 — too old | No |
 | Country Trails Riding | Age 8–14 — too old | No |
 | Humblehorse Ranch | Age 9+ — too old | No |
 | Element Martial Arts | Ends 3:00pm; only 2 weeks; far SE | CAMP-ElementMA.md (flagged) |
 | Elbow Valley Outdoor Camp | Restricted to Elbow Valley residents only | No |
-| Skating Camp | Child doesn't know how to skate | No |
+| Skating Camp (ice) | Child doesn't know how to skate | No |
 | Shooting Stars Summer Intensive | Evening only (4:10–7:30pm) | No |
 | Steamoji (Calgary West + North) | All camps end 3:00pm — below 3:30pm cutoff; no aftercare listed | CAMPS-Steamoji.md |
 | Calgary Zoo Summer Camps | Completely sold out for all 2026 sessions (all age groups); no waitlist | No |
+| Studio Bell — Music Makers (ages 6–9) | Sold out all 2026 sessions | No |
+| North Calgary Dance Centre | Half-day only (9:30am–12:30pm) — below cutoff | No |
+| Mahogany Dance Arts — Unicorn Sparkles | Far SE (~40–55 min); Mon–Thurs only (4 days); ends at 3:30pm | No |
+| SAJRD Southern Alberta Junior Roller Derby | Season runs Sept–June only; no summer program | No |
 
 ---
 
@@ -87,3 +125,7 @@
 | University of Calgary | CAMPS-UofC.md |
 | SAIT | CAMPS-SAIT.md |
 | Steamoji (Calgary West + North) | CAMPS-Steamoji.md |
+| Alien In-Line Inline Skate Camp | CAMP-AlienInLine.md |
+| Chinook School of Music | CAMP-ChinookMusic.md |
+| Heritage Park Prairie Explorers | CAMP-HeritagePark.md |
+| Rundle College (Creative Souls, Theatre, LEGO) | CAMP-RundleCollege.md |


### PR DESCRIPTION
New CAMP files:
- CAMP-AlienInLine.md — inline skate camp, ages 6-8, NW Calgary locations, ~$425/wk
- CAMP-ChinookMusic.md — Magic of Music (ages 5-6), singing/dancing/crafts, NW, 9am-4pm, $375/wk
- CAMP-HeritagePark.md — Prairie Explorers living-history camp, ages 6-9, 9:30am-4pm, $325/wk
- CAMP-RundleCollege.md — Creative Souls/Theatre/LEGO for Grades 1-3, 8:30am-3:30pm, $340-420/wk

TODO.md updates:
- Added phone-call leads: Free House Dance Plus (very close NW, dance styles), Calgary Junior Roller Derby (West Hillhurst, asked about summer camp), PULSE Studios (hip hop dance NW), and follow-up calls for Alien In-Line hours and Chinook dates
- Added new exclusions: Studio Bell sold out, North Calgary Dance Centre half-day, Mahogany Dance Arts Unicorn Sparkles (far SE), SAJRD season Sept-June only

https://claude.ai/code/session_01SZcGr26UTfrfuJ3xDGRSnP