### PR TITLE
Add Google Maps links to camp location fields

### DIFF
--- a/CAMP-AlienInLine.md
+++ b/CAMP-AlienInLine.md
@@ -17,11 +17,11 @@
 
 | Dates | Location | Distance from West Hillhurst | Spots (Age 6–8) |
 |---|---|---|---|
-| July 6–10 | Triwood Arena, NW | ~10 min ✅ | Waitlist |
-| July 20–24 | Huntington Hills Community Assoc., NW | ~20 min ✅ | Available |
-| Aug 4–7 (4 days) | North Glenmore Park Community Assoc., SW | ~20 min | Waitlist |
+| July 6–10 | [Triwood Arena, NW](https://maps.google.com/?q=Triwood+Arena,+Calgary,+AB) | ~10 min ✅ | Waitlist |
+| July 20–24 | [Huntington Hills Community Assoc., NW](https://maps.google.com/?q=Huntington+Hills+Community+Association,+Calgary,+AB) | ~20 min ✅ | Available |
+| Aug 4–7 (4 days) | [North Glenmore Park Community Assoc., SW](https://maps.google.com/?q=North+Glenmore+Park+Community+Association,+Calgary,+AB) | ~20 min | Waitlist |
 | Aug 10–14 | (SW Calgary location) | ~20 min | Available |
-| Aug 17–21 | Montgomery Community Association, NW | ~10 min ✅ | Waitlist |
-| Aug 24–28 | Edgemont Community Association, NW | ~25 min ✅ | Available |
+| Aug 17–21 | [Montgomery Community Association, NW](https://maps.google.com/?q=Montgomery+Community+Association,+Calgary,+AB) | ~10 min ✅ | Waitlist |
+| Aug 24–28 | [Edgemont Community Association, NW](https://maps.google.com/?q=Edgemont+Community+Association,+Calgary,+AB) | ~25 min ✅ | Available |
 
 > ⚠️ **Note:** The camp name is "Alien **In-Line**" — this is **inline skating** (rollerblades), not quad roller skates. Technique transfers but it's not identical to rollerskating. Confirm hours (full day start/end) when booking.

--- a/CAMP-BarJO.md
+++ b/CAMP-BarJO.md
@@ -8,9 +8,9 @@
 
 - **Indoor/Outdoor:** Outdoor ranch / foothills
 - **Ranch hours:** 10:00am–3:00pm ⚠️ (ends before 3:30pm at the ranch; factor in bus return time)
-- **Bus:** Daily Calgary pickup/drop-off at **Central Memorial High School, 5111 21 St SW** (~20 min from West Hillhurst)
+- **Bus:** Daily Calgary pickup/drop-off at **Central Memorial High School, 5111 21 St SW** (~20 min from West Hillhurst) ([map](https://maps.google.com/?q=5111+21+St+SW,+Calgary,+AB))
 - **Price:** ⚠️ Not listed publicly (deposit: $210; early-bird deadline was Jan 15, 2026 — passed). Contact for full pricing.
-- **Location:** 273041 Beaupre Creek Rd, Rocky View County — ~20 min west of Cochrane, ~60 min from West Hillhurst ⚠️
+- **Location:** 273041 Beaupre Creek Rd, Rocky View County — ~20 min west of Cochrane, ~60 min from West Hillhurst ⚠️ ([map](https://maps.google.com/?q=273041+Beaupre+Creek+Rd,+Rocky+View+County,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://www.barjo.ca | info@barjo.ca | 403-561-4488
 - **Contact for:** Full 2026 pricing, bus schedule, remaining week availability

--- a/CAMP-ButterfieldAcres.md
+++ b/CAMP-ButterfieldAcres.md
@@ -13,7 +13,7 @@
 - **Price:** ⚠️ Not published — contact farm directly: Office@ButterfieldAcres.com | 403-239-0638
 - **What's included:** Farm T-shirt, animal memory photo, all activities
 - **Refund policy:** Refund only if camp cancelled due to low registration; substituting another child is allowed if camper can't attend
-- **Location:** 254077 Rocky Ridge Rd, Calgary (NW edge/Rocky Ridge) — ~25 min from West Hillhurst ✅
+- **Location:** 254077 Rocky Ridge Rd, Calgary (NW edge/Rocky Ridge) — ~25 min from West Hillhurst ✅ ([map](https://maps.google.com/?q=254077+Rocky+Ridge+Rd,+Calgary,+AB))
 - **More info / Book:** https://www.butterfieldacres.com/summer-day-camps/
 
 **Bus weeks (Calgary pickup available):**

--- a/CAMP-CYPT.md
+++ b/CAMP-CYPT.md
@@ -12,9 +12,9 @@
 - **Lunch program:** $65/week (snacks + meals) at select sites
 - **Price:** $350/week
 - **Locations (multiple — see below):**
-  - **North:** Unitarian Church of Calgary, 1703–1 St NW — ~8 min from West Hillhurst ✅ (very close)
-  - **South (Riverbend):** Riverbend Community Association, 19 Rivervalley Dr SE — ~35 min
-  - **West:** SCA Community Association, 277 Strathcona Dr SW — ~15 min
+  - **North:** Unitarian Church of Calgary, 1703–1 St NW — ~8 min from West Hillhurst ✅ (very close) ([map](https://maps.google.com/?q=1703+1+St+NW,+Calgary,+AB))
+  - **South (Riverbend):** Riverbend Community Association, 19 Rivervalley Dr SE — ~35 min ([map](https://maps.google.com/?q=19+Rivervalley+Dr+SE,+Calgary,+AB))
+  - **West:** SCA Community Association, 277 Strathcona Dr SW — ~15 min ([map](https://maps.google.com/?q=277+Strathcona+Dr+SW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://cypt.ca/camps/
 

--- a/CAMP-ChinookMusic.md
+++ b/CAMP-ChinookMusic.md
@@ -10,7 +10,7 @@
 - **Hours:** 9:00am–4:00pm Mon–Fri
 - **Before/After Care:** 8:00–9:00am and 4:00–5:00pm ($45 each or $80 combined)
 - **Price:** $375/week (supplies included)
-- **Location:** 1101 48 Ave NW, Calgary — ~15 min from West Hillhurst ✅
+- **Location:** 1101 48 Ave NW, Calgary — ~15 min from West Hillhurst ✅ ([map](https://maps.google.com/?q=1101+48+Ave+NW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://www.chinookschoolofmusic.com/summerdaycamps
 - **Phone:** 403-246-8446 | info@chinookschoolofmusic.com

--- a/CAMP-ClipClop.md
+++ b/CAMP-ClipClop.md
@@ -10,7 +10,7 @@
 - **Hours:** Core camp hours TBD — extended care available **7:30am–5:30pm** ✅
 - **Before/After care:** 7:30am drop-off, 5:30pm pickup — Calgary location ✅
 - **Price:** ⚠️ Not listed publicly — call 587-892-6100 or visit clip-clop.ca to confirm
-- **Location:** Carousel Ridge Stables, 254207 Bearspaw Rd NW, Calgary — ~20–25 min from West Hillhurst ✅
+- **Location:** Carousel Ridge Stables, 254207 Bearspaw Rd NW, Calgary — ~20–25 min from West Hillhurst ✅ ([map](https://maps.google.com/?q=254207+Bearspaw+Rd+NW,+Calgary,+AB))
 - **Prerequisites:** None — beginner-friendly
 - **Sibling discount:** Automatically applied at registration
 - **More info / Book:** https://www.clip-clop.ca | 587-892-6100

--- a/CAMP-ColourOnFire.md
+++ b/CAMP-ColourOnFire.md
@@ -9,8 +9,8 @@
 - **Indoor/Outdoor:** Indoor art studio
 - **Hours:** 8:30am–4:00pm, Mon–Fri (full week) ✅
 - **Price:** $395 + tax / five-day week | half-day options at $195 + tax (AM or PM — excluded)
-- **Location (closer):** Edgemont Community Association, 33 Edgevalley Circle NW — ~20 min from West Hillhurst ✅
-- **Location (further):** Rosscarrock Community Association, 4410–10 Ave SW — ~15 min from West Hillhurst
+- **Location (closer):** Edgemont Community Association, 33 Edgevalley Circle NW — ~20 min from West Hillhurst ✅ ([map](https://maps.google.com/?q=33+Edgevalley+Circle+NW,+Calgary,+AB))
+- **Location (further):** Rosscarrock Community Association, 4410–10 Ave SW — ~15 min from West Hillhurst ([map](https://maps.google.com/?q=4410+10+Ave+SW,+Calgary,+AB))
 - **Prerequisites:** None
 - **Media used:** Acrylic paint, watercolour, chalk pastels, charcoal, coloured pencils, mixed media
 - **What's included:** All art supplies and materials

--- a/CAMP-Confluence.md
+++ b/CAMP-Confluence.md
@@ -11,7 +11,7 @@
 - **Before/After care:** Complimentary 8:00–9:00am and 4:00–5:00pm ✅
 - **Price:** $335–$360 / five-day week | $268 / four-day week
 - **Optional lunch add-on:** $90 (five-day) or $73 (four-day) via Spolumbo's
-- **Location:** 750 9th Ave SE, Calgary (Inglewood) — ~20 min from West Hillhurst
+- **Location:** 750 9th Ave SE, Calgary (Inglewood) — ~20 min from West Hillhurst ([map](https://maps.google.com/?q=750+9+Ave+SE,+Calgary,+AB))
 - **Prerequisites:** Child must be six years old on the first day of their camp (no exemptions)
 - **Group size:** Max 22 campers per group; 2–3 leaders + 1–2 volunteer junior leaders
 - **More info / Book:** https://www.theconfluence.ca/summercamps

--- a/CAMP-ElementMA.md
+++ b/CAMP-ElementMA.md
@@ -10,7 +10,7 @@
 - **Hours:** 9:00am–3:00pm ⚠️ (program end) | After care: 3:00–5:00pm ✅ (available at extra cost)
 - **Before care:** 8:00–9:00am (extra cost)
 - **Price:** $346 + GST / full week | Before/after care extra
-- **Location:** 13226 Macleod Trail SE, Calgary — ~30–35 min from West Hillhurst ⚠️
+- **Location:** 13226 Macleod Trail SE, Calgary — ~30–35 min from West Hillhurst ⚠️ ([map](https://maps.google.com/?q=13226+Macleod+Trail+SE,+Calgary,+AB))
 - **Prerequisites:** None
 - **Disciplines included:** Karate, Muay Thai, Kickboxing, Self-Defense, Yoga
 - **More info / Book:** https://elementyyc.ca/ | 368-993-5668

--- a/CAMP-HeritagePark.md
+++ b/CAMP-HeritagePark.md
@@ -10,7 +10,7 @@
 - **Hours:** 9:30am–4:00pm Mon–Fri
 - **Before/After Care:** Pre-care from 8:30am, aftercare to 5:00pm (cost not listed)
 - **Price:** $325/week (GST exempt); Annual members and Heritage Club VIPs get 15% off
-- **Location:** Heritage Park Historical Village, 1900 Heritage Dr SW — ~20–25 min from West Hillhurst
+- **Location:** Heritage Park Historical Village, 1900 Heritage Dr SW — ~20–25 min from West Hillhurst ([map](https://maps.google.com/?q=1900+Heritage+Dr+SW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://heritagepark.ca/summer-camps/
 - **Spots:**

--- a/CAMP-JKAKarate.md
+++ b/CAMP-JKAKarate.md
@@ -10,7 +10,7 @@
 - **Hours:** 9:00am–4:00pm, Mon–Fri (drop-off 8:45am)
 - **Price:** $310/week | $285/week early bird (pay by Apr 30, 2026)
 - **Full month (4 weeks):** $1,160 | $1,060 early bird
-- **Location:** #2 12127 44 St SE, Calgary — ~30–35 min from West Hillhurst ⚠️ (far — SE)
+- **Location:** #2 12127 44 St SE, Calgary — ~30–35 min from West Hillhurst ⚠️ (far — SE) ([map](https://maps.google.com/?q=12127+44+St+SE,+Calgary,+AB))
 - **Prerequisites:** None (open to beginners and non-students)
 - **What's included:** Karate training, cultural lessons, self-defense, camp t-shirt, daily snack, end-of-week certificate
 - **More info / Book:** https://empowkarate.com/

--- a/CAMP-MRU.md
+++ b/CAMP-MRU.md
@@ -1,6 +1,6 @@
 # MRU (Mount Royal University) Camps — Calgary
 
-**Location:** 4825 Mount Royal Gate SW, Calgary — ~15 min from West Hillhurst
+**Location:** 4825 Mount Royal Gate SW, Calgary — ~15 min from West Hillhurst ([map](https://maps.google.com/?q=4825+Mount+Royal+Gate+SW,+Calgary,+AB))
 **Hours:** 9:00am–4:00pm, Mon–Fri | Complimentary before care 8–9am | after care 4–5pm ✅
 **Ages:** Gr 1–3 (entering Grades 1–3 in fall 2026, ages 5–9)
 **Price:** $400 / five-day week | $320 / four-day week

--- a/CAMP-Pinnovate.md
+++ b/CAMP-Pinnovate.md
@@ -10,7 +10,7 @@
 - **Hours:** 8:15am drop-off | 5:00pm pick-up ✅ (long day — flexible for parents)
 - **Price:** $375 + GST / week (~$394 after 5% GST)
 - **Cancellation:** Free within 1 week of start; $25 fee for date changes (1 free change)
-- **Location:** 137 Mahogany Plaza SE (Mahogany Village, behind Sobeys) — ~35 min from West Hillhurst ⚠️
+- **Location:** 137 Mahogany Plaza SE (Mahogany Village, behind Sobeys) — ~35 min from West Hillhurst ⚠️ ([map](https://maps.google.com/?q=137+Mahogany+Plaza+SE,+Calgary,+AB))
 - **Prerequisites:** None
 - **Contact:** 403-278-9065 | info@pinnovate.ca
 - **More info / Book:** https://pinnovate.ca/camps/

--- a/CAMP-QuestTheatre.md
+++ b/CAMP-QuestTheatre.md
@@ -11,7 +11,7 @@
 - **Drop-off/pick-up:** 8:30–9:00am drop-off | 4:00–4:30pm pick-up
 - **After-care:** Available until 5:00pm, $40/week
 - **Price:** $400/week | $365 early bird (through Mar 21, 2026)
-- **Location:** cSPACE Marda Loop, 1721 29 Ave SW, Calgary — ~15 min from West Hillhurst
+- **Location:** cSPACE Marda Loop, 1721 29 Ave SW, Calgary — ~15 min from West Hillhurst ([map](https://maps.google.com/?q=1721+29+Ave+SW,+Calgary,+AB))
 - **Prerequisites:** None
 - **Group size:** Max 16 campers, 2 professional artist instructors per class ✅ (great for introverted kids)
 - **Included:** Complimentary camp t-shirt + pizza party

--- a/CAMP-RundleCollege.md
+++ b/CAMP-RundleCollege.md
@@ -29,7 +29,7 @@ Multiple themed camps for Grades 1–3 (ages ~6–8). Camps are run in AM + PM "
 - **Indoor/Outdoor:** Mixed (indoor facilities + outdoor space on campus)
 - **Hours:** 8:30am–3:30pm Mon–Fri (extended care 8:00–8:30am and 3:30–4:00pm at no charge)
 - **Price:** $340–$420/week (combo AM+PM)
-- **Location:** 7615 17 Avenue SW, Calgary — ~20–25 min from West Hillhurst
+- **Location:** 7615 17 Avenue SW, Calgary — ~20–25 min from West Hillhurst ([map](https://maps.google.com/?q=7615+17+Ave+SW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://rundle.ab.ca/summercamps/
 - **Phone / Email:** 403-282-8411 | summercamps@rundle.ab.ca

--- a/CAMP-Steam.md
+++ b/CAMP-Steam.md
@@ -11,7 +11,7 @@
 - **Before/After Care:** Before care 7:30–9:00am ($40/week); After care 4:00–5:30pm ($40/week)
 - **Price:** $268/week
 - **Ages:** 6–13 years old ✅ (she qualifies)
-- **Location:** Hillhurst United Church, 1227 Kensington Close NW, Calgary — ~5 min from West Hillhurst ✅✅
+- **Location:** Hillhurst United Church, 1227 Kensington Close NW, Calgary — ~5 min from West Hillhurst ✅✅ ([map](https://maps.google.com/?q=1227+Kensington+Close+NW,+Calgary,+AB))
 - **Prerequisites:** None
 - **Refund deadline:** May 14, 2026 (full refund minus 2.4% processing fee)
 - **More info / Book:** [campsteam.ca/summer-camps/calgary/](https://campsteam.ca/summer-camps/calgary/)

--- a/CAMPS-SAIT.md
+++ b/CAMPS-SAIT.md
@@ -5,7 +5,7 @@
 - **Hours:** 9:00am–4:00pm, Mon–Fri
 - **Price:** $400/session
 - **Before/after care:** Free, no registration needed
-- **Location:** MB026, Stan Grad Centre, SAIT Main Campus, 1301 16 Ave NW — ~15 min from West Hillhurst
+- **Location:** MB026, Stan Grad Centre, SAIT Main Campus, 1301 16 Ave NW — ~15 min from West Hillhurst ([map](https://maps.google.com/?q=1301+16+Ave+NW,+Calgary,+AB))
 - **Swimming:** None
 - **Registration:** https://saitsummercamps.campbrainregistration.com
 - **Contact:** 403-210-5650 | youth.programs@sait.ca

--- a/CAMPS-Steamoji.md
+++ b/CAMPS-Steamoji.md
@@ -12,7 +12,7 @@
 ---
 
 ## Calgary West Location
-- **Address:** #124, 555 Strathcona Blvd SW — ~15–20 min from West Hillhurst
+- **Address:** #124, 555 Strathcona Blvd SW — ~15–20 min from West Hillhurst ([map](https://maps.google.com/?q=555+Strathcona+Blvd+SW,+Calgary,+AB))
 - **Contact:** (403) 863-9398 | calgarywest@steamoji.com
 
 ---
@@ -107,7 +107,7 @@
 ---
 
 ## Calgary North Location (additional dates)
-- **Address:** Unit #2016, 2060 Symons Valley Pkwy NW — ~25–30 min from West Hillhurst
+- **Address:** Unit #2016, 2060 Symons Valley Pkwy NW — ~25–30 min from West Hillhurst ([map](https://maps.google.com/?q=2060+Symons+Valley+Pkwy+NW,+Calgary,+AB))
 - **Contact:** (587) 316-9928 | calgarynorth@steamoji.com
 
 Same camp programs as Calgary West with different week rotations. Notable age-appropriate options:

--- a/CAMPS-UofC.md
+++ b/CAMPS-UofC.md
@@ -12,7 +12,7 @@
 - **Indoor/Outdoor:** Outdoor (rain or shine), plus pool
 - **Hours:** 8:00am–3:45pm, Mon–Fri (full week; Aug 4–7 is 4 days)
 - **Price:** $296 (Jun 29 week) / $370 (all other weeks)
-- **Location:** UCalgary campus — ~10 min from West Hillhurst
+- **Location:** UCalgary campus — ~10 min from West Hillhurst ([map](https://maps.google.com/?q=2500+University+Dr+NW,+Calgary,+AB)) ([map](https://maps.google.com/?q=2500+University+Dr+NW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/totsontreks
 - **Spots:**
@@ -38,7 +38,7 @@
 - **Indoor/Outdoor:** Both — indoor climbing gym + outdoor Natural Adventure Park
 - **Hours:** 8:00am–3:45pm, Mon–Fri (full week; Aug 4–7 is 4 days)
 - **Price:** $400 (5-day weeks) / $320 (4-day week)
-- **Location:** UCalgary campus — ~10 min from West Hillhurst
+- **Location:** UCalgary campus — ~10 min from West Hillhurst ([map](https://maps.google.com/?q=2500+University+Dr+NW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/climbon
 - **Spots:**
@@ -60,7 +60,7 @@
 - **Indoor/Outdoor:** Both — indoor building + outdoor games + pool
 - **Hours:** 8:00am–3:45pm, Mon–Fri (full week; Aug 4–7 is 4 days)
 - **Price:** $296 (Jun 29 & Aug 4–7 weeks) / $370 (all other weeks)
-- **Location:** UCalgary campus — ~10 min from West Hillhurst
+- **Location:** UCalgary campus — ~10 min from West Hillhurst ([map](https://maps.google.com/?q=2500+University+Dr+NW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/minibrickbuilders
 - **Spots:**
@@ -82,7 +82,7 @@
 - **Indoor/Outdoor:** Primarily outdoor + daily indoor activities + pool
 - **Hours:** 8:00am–3:45pm (A) or 9:00am–4:45pm (B), Mon–Fri
 - **Price:** $296 (Jun 29 & Aug 4–7 weeks) / $370 (all other weeks)
-- **Location:** UCalgary campus — ~10 min from West Hillhurst
+- **Location:** UCalgary campus — ~10 min from West Hillhurst ([map](https://maps.google.com/?q=2500+University+Dr+NW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/minioutdoorsports
 - **Spots:**
@@ -105,7 +105,7 @@
 - **Indoor/Outdoor:** Mixed — indoor design studio + outdoor observation in downtown Calgary
 - **Hours:** 8:00am–3:45pm, Mon–Fri (full week; Aug 4–7 is 4 days)
 - **Price:** ~$370/week (shorter weeks ~$296) ⚠️ **Not confirmed** — estimated based on similar design camps
-- **Location:** 801 7 Ave SW, Calgary (SAPL downtown building) — ~15 min from West Hillhurst
+- **Location:** 801 7 Ave SW, Calgary (SAPL downtown building) — ~15 min from West Hillhurst ([map](https://maps.google.com/?q=801+7+Ave+SW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/achievearcitecture
 - **Spots:**
@@ -127,7 +127,7 @@
 - **Indoor/Outdoor:** Mixed — indoor design work + outdoor exploration of downtown
 - **Hours:** 8:00am–3:45pm, Mon–Fri (full week; Aug 4–7 is 4 days)
 - **Price:** ~$370/week (shorter weeks ~$296)
-- **Location:** 801 7 Ave SW, Calgary (SAPL downtown building) — ~15 min from West Hillhurst
+- **Location:** 801 7 Ave SW, Calgary (SAPL downtown building) — ~15 min from West Hillhurst ([map](https://maps.google.com/?q=801+7+Ave+SW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/2193
 - **Spots:**
@@ -148,7 +148,7 @@
 - **Indoor/Outdoor:** Mixed — classroom + outdoor geocaching
 - **Hours:** 9:00am–4:45pm, Mon–Fri (full week; Aug 4–7 is 4 days)
 - **Price:** $370 (5-day weeks) / $296 (4-day weeks)
-- **Location:** UCalgary campus — ~10 min from West Hillhurst
+- **Location:** UCalgary campus — ~10 min from West Hillhurst ([map](https://maps.google.com/?q=2500+University+Dr+NW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/2080
 - **Spots:**
@@ -169,7 +169,7 @@
 - **Indoor/Outdoor:** Indoor (film studio setup)
 - **Hours:** 9:00am–4:45pm, Mon–Fri (Jun 29 week is 4 days)
 - **Price:** $425 (5-day weeks) / $340 (4-day weeks)
-- **Location:** UCalgary campus — ~10 min from West Hillhurst
+- **Location:** UCalgary campus — ~10 min from West Hillhurst ([map](https://maps.google.com/?q=2500+University+Dr+NW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/Stopmotionanimation
 - **Spots:**
@@ -189,7 +189,7 @@
 - **Indoor/Outdoor:** Both — indoor model-making + outdoor exploration around UCalgary's downtown building
 - **Hours:** 8:00am–3:45pm, Mon–Fri (full week; Aug 4–7 is 4 days)
 - **Price:** ~$370/week
-- **Location:** 801 7 Ave SW, Calgary (SAPL downtown building) — ~15 min from West Hillhurst
+- **Location:** 801 7 Ave SW, Calgary (SAPL downtown building) — ~15 min from West Hillhurst ([map](https://maps.google.com/?q=801+7+Ave+SW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/2615
 - **Spots:**
@@ -211,7 +211,7 @@
 - **Indoor/Outdoor:** Outdoor
 - **Hours:** 8:30am–4:00pm, Mon–Fri (full week)
 - **Price:** ~$300/week
-- **Location:** UCalgary campus — ~10 min from West Hillhurst
+- **Location:** UCalgary campus — ~10 min from West Hillhurst ([map](https://maps.google.com/?q=2500+University+Dr+NW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/1346
 - **Spots:**
@@ -232,7 +232,7 @@
 - **Indoor/Outdoor:** Outdoor
 - **Hours:** 9:00am–3:15pm ⚠️ (ends 15 min before our 3:30pm target)
 - **Price:** $425/week
-- **Location:** UCalgary campus — ~10 min from West Hillhurst
+- **Location:** UCalgary campus — ~10 min from West Hillhurst ([map](https://maps.google.com/?q=2500+University+Dr+NW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/1554
 - **Spots:**
@@ -255,7 +255,7 @@
 - **Indoor/Outdoor:** Indoor
 - **Hours:** 9:00am–4:45pm, Mon–Fri
 - **Price:** $296 (Jun 29 week is 4 days)
-- **Location:** UCalgary campus — ~10 min from West Hillhurst
+- **Location:** UCalgary campus — ~10 min from West Hillhurst ([map](https://maps.google.com/?q=2500+University+Dr+NW,+Calgary,+AB))
 - **Prerequisites:** None
 - **More info / Book:** https://activelivingportal.ucalgary.ca/Program/2604
 - **Spots:**
@@ -277,7 +277,7 @@
 - **Indoor/Outdoor:** Primarily indoor gym + some outdoor
 - **Hours:** 8:30am–4:30pm, Mon–Fri (full week; Aug 4–7 is 4 days)
 - **Price:** Not listed ⚠️ — call 403-932-7373 or email cochranegym@ucalgary.ca to get pricing
-- **Location:** Spray Lake Sawmills Family Sport Centre, Cochrane — ~40 min from West Hillhurst
+- **Location:** Spray Lake Sawmills Family Sport Centre, Cochrane — ~40 min from West Hillhurst ([map](https://maps.google.com/?q=Spray+Lake+Sawmills+Family+Sport+Centre,+Cochrane,+AB))
 - **Prerequisites:** None (open to all skill levels)
 - **More info / Book:** https://active-living.ucalgary.ca/programs/ucalgary-summer-camps/cochrane-gymnastics-camps
 - **Spots:**

--- a/PLAN.md
+++ b/PLAN.md
@@ -39,7 +39,7 @@ Notes:
 - **Indoor/Outdoor:** ...
 - **Hours:** ... Mon–Fri (full week) or note if shorter
 - **Price:** $X/week (note if first week is cheaper)
-- **Location:** ... — ~X min from West Hillhurst
+- **Location:** ... — ~X min from West Hillhurst ([map](https://maps.google.com/?q=ADDRESS))
 - **Prerequisites:** None / [what's needed]
 - **More info / Book:** [URL]
 - **Spots:**


### PR DESCRIPTION
Add ([map](URL)) links to every Location field across all CAMP*.md files. Also updates the PLAN.md template to show the map link format.

Closes #8

Generated with [Claude Code](https://claude.ai/code)