### PR TITLE
Update Rundle College camps with real descriptions from website

### DIFF
--- a/CAMP-RundleCollege.md
+++ b/CAMP-RundleCollege.md
@@ -2,32 +2,114 @@
 
 Multiple themed camps for Grades 1–3 (ages ~6–8). Camps are run in AM + PM "combo" pairs — you pick an AM and a PM activity for the week. Both halves are included in the weekly price.
 
-## Creative Souls + [PM Camp] *(Grades 1–3 | Mixed)*
+## Creative Souls *(Grades 1–3 | Mixed)*
 
-**For her:** Hands-on creative crafts, visual art projects, and mixed-media exploration — outdoors-inspired art that lets her imagination run wild.
+**For her:** Hands-on creative crafts, visual art projects, and mixed-media exploration — outdoors-inspired art that lets her imagination run wild. Daily yoga and movement, journaling, music, and nature-based activities. Right up her alley.
 
-**For you:** Art/crafts half of the day; pair with Theatre or another PM camp for a full themed day.
+**For you:** Art/crafts half of the day (AM or PM). Available as PM in Week 1 (paired with Sportz Sizzler AM).
 
 ---
 
 ## Theatre Camp *(Grades 1–3 | Mixed)*
 
-**For her:** Drama games, storytelling, character play — building her own little performance with other kids. Right up her alley for a child who loves stories.
+**For her:** Drama games, storytelling, movement — working with artists to develop and perform an original story. The show gets filmed on a real stage with sound and lighting!
 
-**For you:** Skills-building through drama; builds confidence and creativity.
+**For you:** Skills-building through drama; builds confidence and creativity. Available as PM in Week 3 (paired with Soccer & More AM).
 
 ---
 
 ## LEGO® Camp *(Grades 1–3 | Mixed)*
 
-**For her:** Building and storytelling with LEGO — mid-tier interest satisfied!
+**For her:** Design, build, and problem-solve — bridges, towers, zipline cars! Hands-on challenges and exciting creations.
+
+**For you:** STEAM-based engineering and construction. Available as PM in Weeks 1, 2, and 3.
+
+---
+
+## Sportz Sizzler *(Grades 1–3 | Mixed)*
+
+**For her:** Fast-paced mix of sports — dodgeball, gaga ball, kickball, pickleball, and more. High energy and variety!
+
+**For you:** Active multi-sport day; challenges different muscles and thinking skills. Available as AM in Weeks 1, 2, 3.
+
+---
+
+## Basketball & More *(Grades 1–3 | Mixed)*
+
+**For her:** Basketball drills and games, plus ball sports like dodgeball-style games, handball, and indoor soccer.
+
+**For you:** Follows a national youth basketball program building fundamentals and sportsmanship. AM camp — Week 1.
+
+---
+
+## Stampede Sneak-a-Peek *(Grades 1–3 | Mixed)*
+
+**For her:** Stampede traditions, cowboy activities, themed crafts, Indigenous hoop dancing, and a petting zoo visit! Plus a visit from the official Calgary Stampede team.
+
+**For you:** Culturally rich, themed Week 1 experience. PM camp — Week 1.
+
+---
+
+## Volleyball & More *(Grades 1–3 | Mixed)*
+
+**For her:** Volleyball plus badminton, belly baseball, and tchoukball. Fun mix of rally-point and throwing games.
+
+**For you:** Builds coordination and teamwork. AM camp — Week 2 (waitlist).
+
+---
+
+## Art *(Grades 1–3 | Mixed)*
+
+**For her:** Clay, acrylics, watercolours, pastels — animals, nature, and abstract designs. Step-by-step guidance to create her own masterpiece.
+
+**For you:** Pure visual art exploration. PM camp — Week 2 (waitlist).
+
+---
+
+## STEAM *(Grades 1–3 | Mixed)*
+
+**For her:** Hands-on science, tech, engineering, art, and math activities in a fun collaborative environment.
+
+**For you:** Cross-discipline STEAM projects. PM camp — Week 2 (waitlist).
+
+---
+
+## Soccer & More *(Grades 1–3 | Mixed)*
+
+**For her:** Soccer drills and games plus a variety of sports to build coordination, agility, and motor skills.
+
+**For you:** Recreational and competitive soccer skills alongside multi-sport activities. AM camp — Week 3 (waitlist).
+
+---
+
+## Tech Wizards *(Grades 1–3 | Mixed)*
+
+**For her:** Google Slides, coding with Blockly and Spheros, iMovie, and Green Screen projects — her own iPad to use all week!
+
+**For you:** Digital literacy, coding basics, and safe online habits. Balanced with outdoor breaks. PM camp — Week 3 (waitlist).
+
+---
+
+## Multi-Sport *(Grades 1–3 | Mixed)*
+
+**For her:** Age-appropriate drills and exciting games across multiple sports, led by high-level coaches.
+
+**For you:** Builds confidence, character, and lifelong skills. AM camp — Week 4.
+
+---
+
+## Math+Art Fusion *(Grades 1–3 | Mixed)*
+
+**For her:** Geometry meets graffiti, symmetry meets sketching, numbers meet wow! Hands-on projects where math and art come together in cool ways.
+
+**For you:** Creative STEM exploration — great for kids who love both art and learning. PM camp — Week 4.
 
 ---
 
 **Shared Details (all Rundle camps):**
 
 - **Indoor/Outdoor:** Mixed (indoor facilities + outdoor space on campus)
-- **Hours:** 8:30am–3:30pm Mon–Fri (extended care 8:00–8:30am and 3:30–4:00pm at no charge)
+- **Hours:** 8:30am–3:30pm Mon–Fri (drop-off 8:00–8:30am, pick-up 3:30–4:00pm at no charge)
 - **Price:** $340–$420/week (combo AM+PM)
 - **Location:** 7615 17 Avenue SW, Calgary — ~20–25 min from West Hillhurst ([map](https://maps.google.com/?q=7615+17+Ave+SW,+Calgary,+AB))
 - **Prerequisites:** None
@@ -35,11 +117,15 @@ Multiple themed camps for Grades 1–3 (ages ~6–8). Camps are run in AM + PM "
 - **Phone / Email:** 403-282-8411 | summercamps@rundle.ab.ca
 - **Spots:**
 
-| Dates | Spots |
-|---|---|
-| June 29–July 3 (Week 1) | — |
-| July 6–10 (Week 2) | — |
-| July 13–17 (Week 3) | — |
-| July 20–24 (Week 4) | — |
+| Dates | Available Combos | Price |
+|---|---|---|
+| Week 1 (June 29–July 3) | Basketball & More AM + Stampede PM | $340 |
+| Week 1 (June 29–July 3) | Basketball & More AM + LEGO® PM | $340 |
+| Week 1 (June 29–July 3) | Sportz Sizzler AM + Creative Souls PM | $340 |
+| Week 2 (July 6–10) | ⏳ Waitlist | — |
+| Week 3 (July 13–17) | ⏳ Waitlist | — |
+| Week 4 (July 20–24) | Multi-Sport AM + LEGO® PM | $400 |
+| Week 4 (July 20–24) | Multi-Sport AM + Sportz Sizzler PM | $400 |
+| Week 4 (July 20–24) | Multi-Sport AM + Math+Art Fusion PM | $420 |
 
-> ⚠️ **Note:** Registration opened January 27, 2026. Only 4 weeks offered (ends July 24). Check available combinations on website — specific AM/PM pairings may have limited spots. Also note SW Calgary location (~20–25 min drive).
+> ⚠️ **Note:** Registration opened January 27, 2026. Only 4 weeks offered (ends July 24). Week 1 note: Monday June 29 – Friday July 3 (except Wednesday July 1 — Canada Day). Check available combinations on website — specific AM/PM pairings may have limited spots. Also note SW Calgary location (~20–25 min drive).

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,6 +26,7 @@ Notes:
 - Camp files are split by provider
 - Do not use Facebook as a research source
 - Ask user to confirm when unsure before making changes
+- **Do NOT make up camp descriptions.** If website content is unavailable, leave descriptions blank or note "description needed" — never invent placeholder text. Ask the user to provide the content instead.
 
 
 ## Camp Entry Template


### PR DESCRIPTION
Updates CAMP-RundleCollege.md with actual camp descriptions from rundle.ab.ca/summercamps/. Fixes camp name (Sportz Sizzler), adds all 12 camp types, and updates availability. Also adds a note to PLAN.md about not making up descriptions.

Closes #10

Generated with [Claude Code](https://claude.ai/code)