### PR TITLE
Add CALENDAR-filtered.md with hearted camps only

### DIFF
--- a/CALENDAR-filtered.md
+++ b/CALENDAR-filtered.md
@@ -2,7 +2,7 @@
 
 Filtered to show only ❤️ hearted camps. See [CALENDAR.md](CALENDAR.md) for the full list.
 
-Hearted camps: **Colour on Fire**, **Rundle — Creative Souls**, **Quest Theatre**, **The Confluence**, **SAIT Digital Creators**
+Hearted camps: **Colour on Fire**, **Rundle — Creative Souls+Sportz Sizzler**, **Quest Theatre**, **The Confluence**, **SAIT Digital Creators**, **Enchanted Events Fairy Camp**, **City of Calgary — Arts Ventures**
 
 Weeks run **Sunday to Saturday**. Camp programs typically run Mon–Fri within each week.
 
@@ -32,7 +32,7 @@ Weeks run **Sunday to Saturday**. Camp programs typically run Mon–Fri within e
 
 | Camp                                    | Type            | Notes                               |      |
 | --------------------------------------- | --------------- | ----------------------------------- | ---- |
-| [Rundle College](CAMP-RundleCollege.md) | Multiple combos | $340 · Available (see file)         | ❤️ |
+| [Rundle College](CAMP-RundleCollege.md) | Sportz Sizzler AM + Creative Souls PM | $340 · Available                    | ❤️ |
 
 ---
 
@@ -46,7 +46,6 @@ Weeks run **Sunday to Saturday**. Camp programs typically run Mon–Fri within e
 | [Colour on Fire — Edgemont NW](CAMP-ColourOnFire.md) | Visual Art      | $395                 | ❤️ |
 | [Quest Theatre](CAMP-QuestTheatre.md)                | Drama/Theatre   | $400                 | ❤️ |
 | [SAIT Digital Creators](CAMPS-SAIT.md)               | Coding          | $400 · Open          | ❤️ |
-| [Rundle College](CAMP-RundleCollege.md)              | Multiple combos | Waitlist             | ❤️ |
 
 ---
 
@@ -60,7 +59,6 @@ Weeks run **Sunday to Saturday**. Camp programs typically run Mon–Fri within e
 | [Colour on Fire — Edgemont NW](CAMP-ColourOnFire.md) | Visual Art      | $395                 | ❤️ |
 | [Quest Theatre](CAMP-QuestTheatre.md)                | Drama/Theatre   | $400                 | ❤️ |
 | [The Confluence](CAMP-Confluence.md)                 | Nature/Outdoor  | $360                 | ❤️ |
-| [Rundle College](CAMP-RundleCollege.md)              | Multiple combos | Waitlist             | ❤️ |
 
 ---
 
@@ -74,7 +72,6 @@ Weeks run **Sunday to Saturday**. Camp programs typically run Mon–Fri within e
 | [Colour on Fire — Edgemont NW](CAMP-ColourOnFire.md) | Visual Art      | $395                            | ❤️ |
 | [Quest Theatre](CAMP-QuestTheatre.md)                | Drama/Theatre   | $400                            | ❤️ |
 | [SAIT Digital Creators](CAMPS-SAIT.md)               | Coding          | $400 · Open                     | ❤️ |
-| [Rundle College](CAMP-RundleCollege.md)              | Multiple combos | $400–420 · Available (see file) | ❤️ |
 
 ---
 
@@ -84,10 +81,11 @@ Weeks run **Sunday to Saturday**. Camp programs typically run Mon–Fri within e
 
 | Camp                                                 | Type           | Notes |      |
 | ---------------------------------------------------- | -------------- | ----- | ---- |
-| [Colour on Fire — Rosscarrock](CAMP-ColourOnFire.md) | Visual Art     | $395  | ❤️ |
-| [Colour on Fire — Edgemont NW](CAMP-ColourOnFire.md) | Visual Art     | $395  | ❤️ |
-| [Quest Theatre](CAMP-QuestTheatre.md)                | Drama/Theatre  | $400  | ❤️ |
-| [The Confluence](CAMP-Confluence.md)                 | Nature/Outdoor | $360  | ❤️ |
+| [Colour on Fire — Rosscarrock](CAMP-ColourOnFire.md)    | Visual Art     | $395                                         | ❤️ |
+| [Colour on Fire — Edgemont NW](CAMP-ColourOnFire.md)    | Visual Art     | $395                                         | ❤️ |
+| [Quest Theatre](CAMP-QuestTheatre.md)                   | Drama/Theatre  | $400                                         | ❤️ |
+| [The Confluence](CAMP-Confluence.md)                    | Nature/Outdoor | $360                                         | ❤️ |
+| [City — Arts Ventures](CAMP-CityOfCalgary.md)           | Visual Arts    | $305 · N. Mt Pleasant ~8 min · **2 spots** ⚠️ call first re: age | ❤️ |
 
 ---
 
@@ -138,5 +136,13 @@ Weeks run **Sunday to Saturday**. Camp programs typically run Mon–Fri within e
 > 🎒 Labour Day is **Monday Sep 7** (next week). School starts **Tuesday Sep 8**.
 
 *No camp programs listed for this week — most summer camps have ended.*
+
+---
+
+## Dates TBD
+
+| Camp                                             | Type               | Notes                                              |      |
+| ------------------------------------------------ | ------------------ | -------------------------------------------------- | ---- |
+| [Enchanted Events Fairy Camp](TODO.md)           | Dance/Crafts/Drama | 2026 dates TBA — contact via enchantedevents.ca ⭐ | ❤️ |
 
 ---

--- a/CALENDAR-filtered.md
+++ b/CALENDAR-filtered.md
@@ -2,7 +2,7 @@
 
 Filtered to show only ❤️ hearted camps. See [CALENDAR.md](CALENDAR.md) for the full list.
 
-Hearted camps: **Colour on Fire**, **Rundle — Creative Souls+Sportz Sizzler**, **Quest Theatre**, **The Confluence**, **SAIT Digital Creators**, **Enchanted Events Fairy Camp**, **City of Calgary — Arts Ventures**
+Hearted camps: **Colour on Fire**, **Rundle — Creative Souls+Sportz Sizzler**, **Quest Theatre**, **The Confluence**, **SAIT Digital Creators**, **City of Calgary — Arts Ventures**
 
 Weeks run **Sunday to Saturday**. Camp programs typically run Mon–Fri within each week.
 
@@ -136,13 +136,5 @@ Weeks run **Sunday to Saturday**. Camp programs typically run Mon–Fri within e
 > 🎒 Labour Day is **Monday Sep 7** (next week). School starts **Tuesday Sep 8**.
 
 *No camp programs listed for this week — most summer camps have ended.*
-
----
-
-## Dates TBD
-
-| Camp                                             | Type               | Notes                                              |      |
-| ------------------------------------------------ | ------------------ | -------------------------------------------------- | ---- |
-| [Enchanted Events Fairy Camp](TODO.md)           | Dance/Crafts/Drama | 2026 dates TBA — contact via enchantedevents.ca ⭐ | ❤️ |
 
 ---

--- a/CALENDAR-filtered.md
+++ b/CALENDAR-filtered.md
@@ -1,0 +1,142 @@
+# Summer 2026 Camp Calendar — Hearted Camps Only
+
+Filtered to show only ❤️ hearted camps. See [CALENDAR.md](CALENDAR.md) for the full list.
+
+Hearted camps: **Colour on Fire**, **Rundle — Creative Souls**, **Quest Theatre**, **The Confluence**, **SAIT Digital Creators**
+
+Weeks run **Sunday to Saturday**. Camp programs typically run Mon–Fri within each week.
+
+---
+
+## Holidays
+
+| Date      | Holiday                                  |
+| --------- | ---------------------------------------- |
+| Wed Jul 1 | 🇨🇦 Canada Day (federal)                |
+| Mon Aug 3 | 🌿 Heritage Day (Alberta)               |
+| Mon Sep 7 | 🎒 Labour Day — school starts Tue Sep 8 |
+
+---
+
+## Week 0 — Sun Jun 21 to Sat Jun 27
+
+> 📚 **School ends Wednesday Jun 24.** Camps start the following week.
+
+*No camps available this week.*
+
+---
+
+## Week 1 — Sun Jun 28 to Sat Jul 4
+
+> 🇨🇦 **4-day camp week** — Canada Day is Wednesday Jul 1. Camps run Mon Jun 29, Tue Jun 30, Thu Jul 2, Fri Jul 3.
+
+| Camp                                    | Type            | Notes                               |      |
+| --------------------------------------- | --------------- | ----------------------------------- | ---- |
+| [Rundle College](CAMP-RundleCollege.md) | Multiple combos | $340 · Available (see file)         | ❤️ |
+
+---
+
+## Week 2 — Sun Jul 5 to Sat Jul 11
+
+> Full 5-day camp week (Jul 6–10).
+
+| Camp                                                 | Type            | Notes                |      |
+| ---------------------------------------------------- | --------------- | -------------------- | ---- |
+| [Colour on Fire — Rosscarrock](CAMP-ColourOnFire.md) | Visual Art      | $395                 | ❤️ |
+| [Colour on Fire — Edgemont NW](CAMP-ColourOnFire.md) | Visual Art      | $395                 | ❤️ |
+| [Quest Theatre](CAMP-QuestTheatre.md)                | Drama/Theatre   | $400                 | ❤️ |
+| [SAIT Digital Creators](CAMPS-SAIT.md)               | Coding          | $400 · Open          | ❤️ |
+| [Rundle College](CAMP-RundleCollege.md)              | Multiple combos | Waitlist             | ❤️ |
+
+---
+
+## Week 3 — Sun Jul 12 to Sat Jul 18
+
+> Full 5-day camp week (Jul 13–17).
+
+| Camp                                                 | Type            | Notes                |      |
+| ---------------------------------------------------- | --------------- | -------------------- | ---- |
+| [Colour on Fire — Rosscarrock](CAMP-ColourOnFire.md) | Visual Art      | $395                 | ❤️ |
+| [Colour on Fire — Edgemont NW](CAMP-ColourOnFire.md) | Visual Art      | $395                 | ❤️ |
+| [Quest Theatre](CAMP-QuestTheatre.md)                | Drama/Theatre   | $400                 | ❤️ |
+| [The Confluence](CAMP-Confluence.md)                 | Nature/Outdoor  | $360                 | ❤️ |
+| [Rundle College](CAMP-RundleCollege.md)              | Multiple combos | Waitlist             | ❤️ |
+
+---
+
+## Week 4 — Sun Jul 19 to Sat Jul 25
+
+> Full 5-day camp week (Jul 20–24).
+
+| Camp                                                 | Type            | Notes                           |      |
+| ---------------------------------------------------- | --------------- | ------------------------------- | ---- |
+| [Colour on Fire — Rosscarrock](CAMP-ColourOnFire.md) | Visual Art      | $395                            | ❤️ |
+| [Colour on Fire — Edgemont NW](CAMP-ColourOnFire.md) | Visual Art      | $395                            | ❤️ |
+| [Quest Theatre](CAMP-QuestTheatre.md)                | Drama/Theatre   | $400                            | ❤️ |
+| [SAIT Digital Creators](CAMPS-SAIT.md)               | Coding          | $400 · Open                     | ❤️ |
+| [Rundle College](CAMP-RundleCollege.md)              | Multiple combos | $400–420 · Available (see file) | ❤️ |
+
+---
+
+## Week 5 — Sun Jul 26 to Sat Aug 1
+
+> Full 5-day camp week (Jul 27–31).
+
+| Camp                                                 | Type           | Notes |      |
+| ---------------------------------------------------- | -------------- | ----- | ---- |
+| [Colour on Fire — Rosscarrock](CAMP-ColourOnFire.md) | Visual Art     | $395  | ❤️ |
+| [Colour on Fire — Edgemont NW](CAMP-ColourOnFire.md) | Visual Art     | $395  | ❤️ |
+| [Quest Theatre](CAMP-QuestTheatre.md)                | Drama/Theatre  | $400  | ❤️ |
+| [The Confluence](CAMP-Confluence.md)                 | Nature/Outdoor | $360  | ❤️ |
+
+---
+
+## Week 6 — Sun Aug 2 to Sat Aug 8
+
+> 🌿 **4-day camp week** — Heritage Day is Monday Aug 3. Most camps run Tue Aug 4 through Fri Aug 7. Quest Theatre lists "Aug 3–7" — confirm directly if attending.
+
+| Camp                                  | Type          | Notes                                |      |
+| ------------------------------------- | ------------- | ------------------------------------ | ---- |
+| [Quest Theatre](CAMP-QuestTheatre.md) | Drama/Theatre | $400 · Aug 3–7 · confirm Heritage Day | ❤️ |
+
+---
+
+## Week 7 — Sun Aug 9 to Sat Aug 15
+
+> Full 5-day camp week (Aug 10–14).
+
+| Camp                                                 | Type           | Notes           |      |
+| ---------------------------------------------------- | -------------- | --------------- | ---- |
+| [Colour on Fire — Rosscarrock](CAMP-ColourOnFire.md) | Visual Art     | $395            | ❤️ |
+| [Colour on Fire — Edgemont NW](CAMP-ColourOnFire.md) | Visual Art     | $395            | ❤️ |
+| [Quest Theatre](CAMP-QuestTheatre.md)                | Drama/Theatre  | $400            | ❤️ |
+| [The Confluence](CAMP-Confluence.md)                 | Nature/Outdoor | $360            | ❤️ |
+| [SAIT Digital Creators](CAMPS-SAIT.md)               | Coding         | $400 · Waitlist | ❤️ |
+
+---
+
+## Week 8 — Sun Aug 16 to Sat Aug 22
+
+> Full 5-day camp week (Aug 17–21). Note: UCalgary pool closed Aug 18–22 for maintenance.
+
+| Camp                                                 | Type       | Notes |      |
+| ---------------------------------------------------- | ---------- | ----- | ---- |
+| [Colour on Fire — Edgemont NW](CAMP-ColourOnFire.md) | Visual Art | $395  | ❤️ |
+
+---
+
+## Week 9 — Sun Aug 23 to Sat Aug 29
+
+> Full 5-day camp week (Aug 24–28).
+
+*No hearted camps available this week.*
+
+---
+
+## Week 10 — Sun Aug 30 to Sat Sep 5
+
+> 🎒 Labour Day is **Monday Sep 7** (next week). School starts **Tuesday Sep 8**.
+
+*No camp programs listed for this week — most summer camps have ended.*
+
+---

--- a/CALENDAR.md
+++ b/CALENDAR.md
@@ -347,4 +347,3 @@ These camps run during the summer but specific weeks are not published online:
 | [WinSport Wilderness Explorers](CAMP-WinSport.md) | Outdoor/Nature      | 9 weeks Jun 29–Aug 28 · Ages 4–8 · $296–370/wk · Free before/after care  |
 | [WinSport Summer Sampler](CAMP-WinSport.md)       | Multi-Activity      | 9 weeks Jun 29–Aug 28 · Ages 6–8 · $296–370/wk · Free before/after care  |
 | [Free House Dance Plus](CAMP-FreeHouseDance.md)   | Dance (multi-style) | Jul 13–17, Jul 20–24 confirmed · more weeks TBC · call for details       |
-| [Enchanted Events Fairy Camp](TODO.md)            | Dance/Crafts/Drama  | 2026 dates TBA — contact via enchantedevents.ca ⭐ HIGH PRIORITY         |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@
 
 |     | Camp                                   | What you do                                                                   | $/wk         | Notes                                                   |
 | --- | -------------------------------------- | ----------------------------------------------------------------------------- | ------------ | ------------------------------------------------------- |
-| ❤️ | **Enchanted Events** — Fairy Camp      | Fairy crafts, dance, drama, singing, and magical adventures — graduation show | ⚠️ Contact | ✅✅ 5 min away; 2026 dates TBA ⭐                      |
 |     | **Free House Dance Plus** — Dance Camp | Ballet, jazz, tap, lyrical, musical theatre — all in one week                 | $375         | ✅✅ 5 min away; Jul 13–17 & Jul 20–24 only; after care |
 |     | **PULSE Studios** — Hip Hop Camp       | Breaking, popping, house dance, and group choreography                        | $395+GST     | ✅ 10 min away; 7 weeks; street styles ⚠️             |
 |     | **StoryBook Theatre** — Theatre Camps  | Write, cast, rehearse, and perform an original play by Friday                 | $375         | ✅ ~15–20 min NW; 9am–4pm; FREE after care; 6 weeks     |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 |     | Camp                                   | What you do                                                                   | $/wk         | Notes                                                   |
 | --- | -------------------------------------- | ----------------------------------------------------------------------------- | ------------ | ------------------------------------------------------- |
-|     | **Enchanted Events** — Fairy Camp      | Fairy crafts, dance, drama, singing, and magical adventures — graduation show | ⚠️ Contact | ✅✅ 5 min away; 2026 dates TBA ⭐                      |
+| ❤️ | **Enchanted Events** — Fairy Camp      | Fairy crafts, dance, drama, singing, and magical adventures — graduation show | ⚠️ Contact | ✅✅ 5 min away; 2026 dates TBA ⭐                      |
 |     | **Free House Dance Plus** — Dance Camp | Ballet, jazz, tap, lyrical, musical theatre — all in one week                 | $375         | ✅✅ 5 min away; Jul 13–17 & Jul 20–24 only; after care |
 |     | **PULSE Studios** — Hip Hop Camp       | Breaking, popping, house dance, and group choreography                        | $395+GST     | ✅ 10 min away; 7 weeks; street styles ⚠️             |
 |     | **StoryBook Theatre** — Theatre Camps  | Write, cast, rehearse, and perform an original play by Friday                 | $375         | ✅ ~15–20 min NW; 9am–4pm; FREE after care; 6 weeks     |
@@ -60,7 +60,7 @@
 |     | Camp                                      | What you do                                                                | $/wk | Notes                                                                 |
 | --- | ----------------------------------------- | -------------------------------------------------------------------------- | ---- | --------------------------------------------------------------------- |
 |     | **City of Calgary** — Rec Adventures (NW) | Games, sports, crafts, outdoor adventures, park trips, and swimming        | $269 | ✅✅ Shouldice Aquatic Centre, ~10 min; spots available               |
-|     | **City of Calgary** — Arts Ventures (NW)  | Drawing, painting, mixed media, and sculpture — take-home artwork          | $305 | ✅ N. Mt Pleasant Arts Centre, ~8 min; **mostly full** ⚠️           |
+| ❤️ | **City of Calgary** — Arts Ventures (NW)  | Drawing, painting, mixed media, and sculpture — take-home artwork          | $305 | ✅ N. Mt Pleasant Arts Centre, ~8 min; **mostly full** ⚠️           |
 |     | **City of Calgary** — Arts & Dance        | Art techniques + dance — create choreography and artwork each day          | $290 | 7–9 age group **sold out**; Wildflower Arts Centre (SW, ~20 min) ⚠️ |
 |     | **City of Calgary** — Rock Climbing       | 2 hrs/day bouldering + climbing-wall instruction, plus crafts and swimming | $285 | **Completely sold out** ❌; Southland (SW, ~25 min)                   |
 |     | **City of Calgary** — Field Sports        | Ultimate frisbee, soccer, lacrosse — park trips and water activities       | $269 | Lots of spots; locations SE/SW (~25–35 min) ⚠️                      |

--- a/TODO.md
+++ b/TODO.md
@@ -66,15 +66,10 @@
 - **Schedule updated:** New 2026 locations confirmed — Triwood (Jul 6–10, waitlist), Huntington Hills (Jul 20–24, available), Montgomery (Aug 17–21, waitlist), Edgemont (Aug 24–28, available). Also Airdrie and SE locations.
 - **Status:** No further action needed — register at https://register.alieninline.com/summer-skate-camps-2026
 
-### Enchanted Events — Fairy Camp ✅✅✅ Extremely Close (NW) ⭐ HIGH PRIORITY
-- **What:** Fairy-themed week camp with daily activities — crafts, dance, drama, singing, creative movement, and fairy training. Ends with a graduation show for families on the final day.
-- **Ages:** 4–8 years — she qualifies ✅
-- **Hours:** 9:00am–4:00pm ✅
-- **Location:** #9, 213 19th St NW, Calgary (Kensington area) — ~5 min from West Hillhurst ✅✅
-- **Note:** 2026 dates not yet published online. $75 non-refundable deposit required at registration.
-- **Action:** Contact via https://www.enchantedevents.ca/fairy_camp_1.html — ask: (1) When are the 2026 summer dates? (2) What is the per-week price?
-- **Why high priority:** Fairy/unicorn theme + dance + crafts + singing + drama = hits every one of her top interests. Closest possible location.
-- **Website:** https://www.enchantedevents.ca/fairy_camp_1.html
+### ~~Enchanted Events — Fairy Camp~~ ❌ EXCLUDED (out of business)
+- **Reason:** Enchanted Events is no longer in business as of 2026. Removed from all calendars, summary, and maps.
+- **What was:** Fairy-themed week camp with daily activities — crafts, dance, drama, singing, creative movement, and fairy training. Ends with a graduation show for families on the final day.
+- **Location was:** #9, 213 19th St NW, Calgary (Kensington area) — ~5 min from West Hillhurst
 
 ### StoryBook Theatre — Summer Theatre Camps ✅ Close (NW) — ✅ CONFIRMED
 - **What:** Week-long theatre camps, create and perform an original play by Friday. Ages split into Groundlings (6–7), Minstrels (8–9), Jesters (10–12). **CAMP-StorybookTheatre.md created.**

--- a/map.geojson
+++ b/map.geojson
@@ -435,18 +435,6 @@
     },
     {
       "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-114.0975, 51.0595] },
-      "properties": {
-        "name": "Enchanted Events (Fairy Camp)",
-        "address": "#9, 213 19th St NW, Calgary, AB",
-        "category": "Arts & Design",
-        "description": "Fairy-themed camp -- crafts, dance, drama, singing, magical adventures. Ages 4-8. 9am-4pm. 2026 dates TBA -- contact to register interest. ~5 min from home. TOP PICK. https://www.enchantedevents.ca/fairy_camp_1.html",
-        "marker-color": "#7B2D8B",
-        "marker-symbol": "star"
-      }
-    },
-    {
-      "type": "Feature",
       "geometry": { "type": "Point", "coordinates": [-114.2281, 51.0786] },
       "properties": {
         "name": "WinSport (Wilderness Explorers)",


### PR DESCRIPTION
Creates a slimmed-down CALENDAR-filtered.md filtered to only show the ❤️ hearted camps from README.md: Colour on Fire, Rundle Creative Souls, Quest Theatre, The Confluence, and SAIT Digital Creators.

Closes #14

Generated with [Claude Code](https://claude.ai/code)